### PR TITLE
fix: include `-` as identifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -329,7 +329,7 @@ module.exports = grammar({
 
     indexed_field: $ => seq('[', choice($.identifier, $.string), ']'),
 
-    identifier: _ => /[a-zA-Z_][a-zA-Z0-9_]*/,
+    identifier: _ => /[a-zA-Z_][a-zA-Z0-9_-]*/,
 
     diagnostic_identifier: _ => /[a-zA-Z_][a-zA-Z0-9_-]*/,
   },

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -95,7 +95,7 @@ Test a Return Annotation
 Test a Type Annotation
 =======================
 
-@type Car
+@type Car-Car
 
 ---
 


### PR DESCRIPTION
Parser only match "fzf" as a type here rather than "fzf-lua.xx".
```lua
---@class fzf-lua.foo
---@field bar
```

Since `lua-language-server`'s semantic token highlighting work properly, if we can include `-` as a `identifier` here?

The disadvantage is that it will also highlight `-baz` in `@field bar-baz` (which seems unexpected).

Or separate `type_identifier` (e.g. only for `@class`/`@type`/`@as`/`@alias`/...) from `identifier`, but it seems too overkill (which need to tweak some test and upstream query in `nvim-treesitter` repo).
